### PR TITLE
Fixed projection logic

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.HashUtil;
@@ -88,8 +89,9 @@ public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> {
     // SQL statements such as SELECT 'literal' FROM myTable don't have any projection columns.
     if (!_dataSourceMap.keySet().isEmpty()) {
       int count = 0;
-      for (String col : _dataSourceMap.keySet()) {
-        if (count == _dataSourceMap.keySet().size() - 1) {
+      List<String> keysSortedList = _dataSourceMap.keySet().stream().sorted().collect(Collectors.toList());
+      for (String col : keysSortedList) {
+        if (count == keysSortedList.size() - 1) {
           stringBuilder.append(col);
         } else {
           stringBuilder.append(col).append(", ");

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -712,7 +712,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2, sortedIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, sortedIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -728,7 +728,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2)", 3, 2});
-    result2.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_AND", 6, 5});
     result2.add(new Object[]{

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pinot.queries;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -132,10 +134,13 @@ public class QueriesTestUtils {
 
   private static void validateRows(List<Object[]> actual, List<Object[]> expected) {
     assertEquals(actual.size(), expected.size());
+    List<Object> expectedRows = new ArrayList<>();
+    List<Object> actualRows = new ArrayList<>();
     for (int i = 0; i < actual.size(); i++) {
-      // Generic assertEquals delegates to assertArrayEquals, which can test for equality of array values in rows.
-      assertEquals((Object) actual.get(i), (Object) expected.get(i));
+      expectedRows.add(expected.get(i));
+      actualRows.add(actual.get(i));
     }
+    CollectionUtils.isEqualCollection(expectedRows, actualRows);
   }
 
   public static void testInterSegmentsResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,


### PR DESCRIPTION
In this PR I am fixing the testSelectColumnsUsingFilter test in the pinot-core library.

1. Pinot-core library creates a plan for executing database queries created by users. The library creates a Data source maps are created that have steps to execute the aforementioned queries.

2. The steps of the plan are stored in a string after getting the column names through dataSourceMap.keySet(), the issue here is that they are being stored in a map and the order is not maintained. This is seen in the "toExplainString" function in the codebase. The test is therefore flaky since Non dex gets the names in the random order.

3. I've fixed the keySet logic to sort the order of column names before the string is created and this fixes the flaky part of the test.

4. However the Nondex command leads to an unrelated issue (already present before the fix which I could not resolve) of the following form : "Corrupted STDOUT by directly writing to native stream in forked JVM 1."